### PR TITLE
feat: add npx run-claude-artifact command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,30 @@ A template project for easily converting Claude AI’s Artifacts into React appl
 
 ## TL/DR
 
-1. You created a fancy web app using Claude's Artifacts feature.
+1. You created a fancy web app or UI component using Claude's Artifacts feature.
 2. You want to run it outside of Claude's website, or use it as a base for a larger project.
-3. Clone, install and run this project.
-4. Save your artifact(s) to the correct folder.
+
+### The fast way (1 command)
+3. Download the Artifact to your local machine, as a `.tsx` or `.jsx` file.
+4. Run `npx run-claude-artifact <path-to-file>` to run the Artifact locally and preview it in your browser.
 5. Done!
-6. Optional step: continue developing your project into a full-fledged web application.
-7. Optional step: generate a release build and publish your finished application to a web server or cloud service.
+6. When done viewing the Artifact, press `Ctrl+C` on the terminal to stop the development server and discard the temporary project.
 
-## Run an Artifact without installing this project
+> **Note:** If you just want to try out the project and don’t have an Artifact yet, you can just run `npx run-claude-artifact` to see the default demo Artifacts (created with Claude).
 
-If you just want to preview a single Artifact without cloning this repository, you can run it directly with npx:
+### Alternatively
+1. Clone, install and run this project.
+2. Save your artifact to the correct folder.
+3. Run `npm run dev` to start the development server.
+4. Open your browser and visit `http://localhost:5173`.
+5. Done!
+6. When done viewing the Artifact, press `Ctrl+C` on the terminal to stop the development server, or leave it running to continue developing your project and see your changes immediately reflected in the browser.
 
-```bash
-npx run-claude-artifact <filename> [--keep]
-```
+> See detailed installation and development instructions further below.
 
-Use `--keep` to preserve the project; without it the temporary folder is removed when the preview server exits.
+### Optional steps
+1. Continue developing your project into a full-fledged web application.
+2. Generate a release build and publish your finished application to a web server or cloud service.
 
 ## Use Cases
 
@@ -31,30 +38,43 @@ Use `--keep` to preserve the project; without it the temporary folder is removed
 
 ## Table of Contents
 
-- [Why is this needed?](#why-is-this-needed)
-- [What this project is not](#what-this-project-is-not)
-- [What this project actually is](#what-this-project-actually-is)
-- [Limitations](#limitations)
-- [What's included?](#whats-included)
-- [Prerequisites](#prerequisites)
-- [Getting started](#getting-started)
-- [Running a single Artifact](#running-a-single-artifact)
-- [Creating a multi-page application](#creating-a-multi-page-application)
-- [Developing a more complex application](#developing-a-more-complex-application)
-- [Project structure](#project-structure)
-- [Building for production](#building-for-production)
-- [Deploying your application](#deploying-your-application)
-  - [Local test deployment](#local-test-deployment)
-  - [Traditional web hosting](#traditional-web-hosting)
-  - [Cloud hosting platforms](#cloud-hosting-platforms)
-     - [Netlify](#netlify)
-     - [Vercel](#vercel)
-     - [GitHub Pages](#github-pages)
-     - [Cloudflare Pages](#cloudflare-pages)
-- [Troubleshooting](#troubleshooting)
-- [Contributing](#contributing)
-- [License](#license)
-- [Acknowledgements](#acknowledgements)
+- [Claude Artifact Runner](#claude-artifact-runner)
+  - [TL/DR](#tldr)
+    - [The fast way (1 command)](#the-fast-way-1-command)
+    - [Alternatively](#alternatively)
+    - [Optional steps](#optional-steps)
+  - [Use Cases](#use-cases)
+  - [Table of Contents](#table-of-contents)
+  - [Why is this needed?](#why-is-this-needed)
+  - [What this project is not](#what-this-project-is-not)
+  - [What this project actually is](#what-this-project-actually-is)
+  - [Limitations](#limitations)
+  - [What's included?](#whats-included)
+  - [Prerequisites](#prerequisites)
+  - [Installation](#installation)
+    - [Option 1: Use npx - Fast and easy](#option-1-use-npx---fast-and-easy)
+    - [Option 2: Clone the repository](#option-2-clone-the-repository)
+  - [Installing a single Artifact](#installing-a-single-artifact)
+  - [Creating a multi-page application](#creating-a-multi-page-application)
+  - [Developing a more complex application](#developing-a-more-complex-application)
+    - [Customization](#customization)
+    - [Removing unneeded components / libraries](#removing-unneeded-components--libraries)
+      - [Unneeded Shadcn UI components:](#unneeded-shadcn-ui-components)
+      - [Unneeded packages (ex: Recharts):](#unneeded-packages-ex-recharts)
+  - [Project structure](#project-structure)
+  - [Building for production](#building-for-production)
+  - [Deploying your application](#deploying-your-application)
+    - [Local test deployment](#local-test-deployment)
+    - [Traditional web hosting](#traditional-web-hosting)
+    - [Cloud hosting platforms](#cloud-hosting-platforms)
+      - [Netlify](#netlify)
+      - [Vercel](#vercel)
+      - [GitHub Pages](#github-pages)
+      - [Cloudflare Pages](#cloudflare-pages)
+  - [Troubleshooting](#troubleshooting)
+  - [Contributing](#contributing)
+  - [License](#license)
+  - [Acknowledgements](#acknowledgements)
 
 ## Why is this needed?
 
@@ -128,12 +148,36 @@ Before you begin, ensure you have the following installed:
   minimum supported version is 16 (lts/gallium), tested up to version 23.2, version 22.11 is recommended
 - npm (usually comes with Node.js)
 
-## Getting started
+## Installation
 
-1. Clone the repository:
+Start by downloading your Artifact to your local machine, as a `.tsx` or `.jsx` file.
+
+Then you have 2 ways to install your Artifacts into a local project.
+
+### Option 1: Use npx - Fast and easy
+
+```bash
+npx run-claude-artifact [<filename>] [--keep]
+```
+
+A browser window will open and you'll see your Artifact running.
+
+> **Note:** If no filename is provided, the default demo components will be displayed.
+
+> **Note:** Use `--keep` to install the project, in the current directory, as a folder named after the file (without extension).  
+> Without `--keep`, the project is installed in a temporary folder and removed when the preview server exits.
+
+If you used the `--keep` option, you'll be able to continue developing the project.
+
+In that case, continue reading from the [Installing a single Artifact](#installing-a-single-artifact) section.
+
+### Option 2: Clone the repository
+
+1. Clone and degit the repository:
    ```
    git clone https://github.com/claudio-silva/claude-artifact-runner.git
    cd claude-artifact-runner
+   rm -rf .git  # Disassociate from the original repository - RECOMMENDED - it's your local project now
    ```
 
 2. Install dependencies:
@@ -148,22 +192,23 @@ Before you begin, ensure you have the following installed:
 
 4. Open your browser and visit `http://localhost:5173` to see the default app running.
 
-The default app is composed of two demo components: a login form and a signup form. You can navigate between them by clicking on the link at the bottom of the form.
+The default app is composed of two demo components: a **login form** and a **signup form**. You can navigate between them by clicking on the link at the bottom of the form.
 
 > These demo pages/components are just for demonstration purposes and can be easily replaced with your own components, either generated by Claude or created by yourself.  
 > **This will NOT be the UI of your application.**
 
-## Running a single Artifact
+## Installing a single Artifact
 
-If you just want to run a single Artifact, you can follow these simple steps:
+If you just want to install a single Artifact on the local project, you can follow these simple steps:
 
-1. Follow the "Getting started" steps. Leave the browser open at the initial page.
-2. Delete the files in the `src/artifacts/` directory.
-3. Download your Artifact from Claude.ai
-4. Move the file to the `src/artifacts/` directory and rename it to `index.tsx`.
-5. You'll immediately see your Artifact running on the open browser tab.
+1. Follow the [Installation](#installation) steps (option 1 with `--keep` or option 2).
+2. Leave the browser open at the initial page and leave the development server running.
+3. Delete the files in the `src/artifacts/` directory.
+4. Download your Artifact from Claude.ai
+5. Move the file to the `src/artifacts/` directory and rename it to `index.tsx`.
+6. You'll immediately see your Artifact running on the open browser tab.
 
-Note that you'll be viewing the app in development mode. To generate the final app, ready for production, you'll need to build it first. See the instructions further below.
+> **Note:** You'll be viewing the app in development mode. To generate the final app, ready for production, you'll need to build it first. See the instructions further below.
 
 ## Creating a multi-page application
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ A template project for easily converting Claude AI’s Artifacts into React appl
 6. Optional step: continue developing your project into a full-fledged web application.
 7. Optional step: generate a release build and publish your finished application to a web server or cloud service.
 
+## Run an Artifact without installing this project
+
+If you just want to preview a single Artifact without cloning this repository, you can run it directly with npx:
+
+```bash
+npx run-claude-artifact <filename> [--keep]
+```
+
+Use `--keep` to preserve the project; without it the temporary folder is removed when the preview server exits.
+
 ## Use Cases
 
 1. Run Artifacts on your local machine, on a web server or on a cloud service.

--- a/npx/README.md
+++ b/npx/README.md
@@ -1,0 +1,48 @@
+# run-claude-artifact
+
+This directory contains a small npm package that exposes the `run-claude-artifact` command.
+It clones the `claude-artifact-runner` project, injects your artifact and launches Vite so you
+can preview it without manually installing the project.
+
+## Usage
+
+```bash
+npx run-claude-artifact <filename> [--keep]
+```
+
+- `<filename>`: Path to a `.tsx` or `.jsx` component file.
+- `--keep`: If provided, the cloned project is moved to a folder named after the file (without extension).
+
+## Developing locally
+
+1. Install dependencies (none for now) and run the test script:
+   ```bash
+   cd npx
+   npm test
+   ```
+2. To experiment with the CLI before publishing, link it globally:
+   ```bash
+   npm link
+   run-claude-artifact path/to/file.tsx
+   ```
+   Or execute it directly with Node:
+   ```bash
+   node run-claude-artifact.js path/to/file.tsx
+   ```
+
+## Publishing
+
+1. Sign in to npm if needed:
+   ```bash
+   npm login
+   ```
+2. Publish the package from this directory:
+   ```bash
+   npm publish --access public
+   ```
+
+After publishing, anyone can run an artifact with:
+
+```bash
+npx run-claude-artifact my-artifact.tsx
+```

--- a/npx/package.json
+++ b/npx/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "run-claude-artifact",
+  "version": "1.0.0",
+  "description": "Run a Claude artifact without installing the full project",
+  "bin": {
+    "run-claude-artifact": "./run-claude-artifact.js"
+  },
+  "scripts": {
+    "build": "echo \"nothing to build\"",
+    "test": "node run-claude-artifact.js --help"
+  },
+  "author": "Cl\u00e1udio Silva",
+  "license": "MIT"
+}

--- a/npx/run-claude-artifact.js
+++ b/npx/run-claude-artifact.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+const { spawn } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function run(cmd, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const p = spawn(cmd, args, { stdio: 'inherit', ...options });
+    p.on('exit', code => {
+      if (code === 0) resolve();
+      else reject(new Error(`${cmd} exited with code ${code}`));
+    });
+  });
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    console.log(`Usage: run-claude-artifact <filename> [--keep]\n\n<filename>  Path to a .tsx or .jsx file\n--keep      Keep the cloned project after exit`);
+    return;
+  }
+  const fileArg = args[0];
+  const keep = args.includes('--keep');
+  const cwd = process.cwd();
+  const absFile = path.resolve(cwd, fileArg);
+  if (!fs.existsSync(absFile)) {
+    console.error(`File not found: ${absFile}`);
+    process.exit(1);
+  }
+  if (!/(\.tsx|\.jsx)$/i.test(absFile)) {
+    console.error('File must have .tsx or .jsx extension');
+    process.exit(1);
+  }
+
+  const tmpBase = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'claude-artifact-'));
+  const repoDir = path.join(tmpBase, 'repo');
+  const repoUrl = 'https://github.com/claudio-silva/claude-artifact-runner';
+
+  console.log('Cloning project...');
+  await run('git', ['clone', repoUrl, repoDir]);
+
+  console.log('Installing dependencies...');
+  await run('npm', ['install'], { cwd: repoDir });
+
+  const targetArtifact = path.join(repoDir, 'src', 'artifacts', 'index.tsx');
+  await fs.promises.copyFile(absFile, targetArtifact);
+
+  console.log('Building artifact...');
+  await run('npx', ['vite', 'build'], { cwd: repoDir });
+
+  console.log('Starting preview server... (press Ctrl+C to stop)');
+  const preview = spawn('npx', ['vite', 'preview'], { cwd: repoDir, stdio: 'inherit' });
+  process.on('SIGINT', () => preview.kill('SIGINT'));
+
+  preview.on('exit', async () => {
+    if (keep) {
+      const dest = path.join(cwd, path.basename(fileArg, path.extname(fileArg)));
+      await fs.promises.rm(dest, { recursive: true, force: true });
+      await fs.promises.rename(repoDir, dest);
+      await fs.promises.rm(tmpBase, { recursive: true, force: true });
+      console.log(`Project kept at ${dest}`);
+    } else {
+      await fs.promises.rm(tmpBase, { recursive: true, force: true });
+      console.log('Temporary project removed');
+    }
+  });
+}
+
+main().catch(err => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/npx/run-claude-artifact.js
+++ b/npx/run-claude-artifact.js
@@ -14,60 +14,92 @@ function run(cmd, args, options = {}) {
   });
 }
 
+async function cleanup(tmpBase, keep, cwd, fileArg, repoDir) {
+  try {
+    if (keep) {
+      const dest = path.join(cwd, path.basename(fileArg, path.extname(fileArg)));
+      await fs.promises.rm(dest, { recursive: true, force: true });
+      await fs.promises.rename(repoDir, dest);
+      await fs.promises.rm(tmpBase, { recursive: true, force: true });
+      console.log(`${os.EOL}Project kept at ${dest}`);
+    } else {
+      await fs.promises.rm(tmpBase, { recursive: true, force: true });
+      console.log(`${os.EOL}Temporary project removed`);
+    }
+  } catch (err) {
+    console.warn(`${os.EOL}Warning: Failed to cleanup temporary directory:`, err.message);
+  }
+}
+
 async function main() {
   const args = process.argv.slice(2);
-  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
-    console.log(`Usage: run-claude-artifact <filename> [--keep]\n\n<filename>  Path to a .tsx or .jsx file\n--keep      Keep the cloned project after exit`);
+
+  // Handle help request
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(`Usage: run-claude-artifact [filename] [--keep]\n\n[filename]  Path to a .tsx or .jsx file (optional)\n--keep       Keep the cloned project after exit\n\nIf no filename is provided, the default artifact will be displayed.`);
     return;
   }
-  const fileArg = args[0];
+
   const keep = args.includes('--keep');
   const cwd = process.cwd();
-  const absFile = path.resolve(cwd, fileArg);
-  if (!fs.existsSync(absFile)) {
-    console.error(`File not found: ${absFile}`);
-    process.exit(1);
-  }
-  if (!/(\.tsx|\.jsx)$/i.test(absFile)) {
-    console.error('File must have .tsx or .jsx extension');
-    process.exit(1);
+
+  let absFile = null;
+  let fileArg = null;
+  let useDefault = false;
+
+  if (args.length > 0 && !args[0].startsWith('--')) {
+    // Filename provided
+    fileArg = args[0];
+    absFile = path.resolve(cwd, fileArg);
+    if (!fs.existsSync(absFile)) {
+      console.error(`File not found: ${absFile}`);
+      process.exit(1);
+    }
+    if (!/(\.tsx|\.jsx)$/i.test(absFile)) {
+      console.error('File must have .tsx or .jsx extension');
+      process.exit(1);
+    }
+  } else {
+    // No filename provided - use default
+    useDefault = true;
+    console.log('📁 No artifact file provided - running with default content');
   }
 
   const tmpBase = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'claude-artifact-'));
   const repoDir = path.join(tmpBase, 'repo');
   const repoUrl = 'https://github.com/claudio-silva/claude-artifact-runner';
 
-  console.log('Cloning project...');
-  await run('git', ['clone', repoUrl, repoDir]);
+  try {
+    console.log('Cloning project...');
+    await run('git', ['clone', repoUrl, repoDir]);
 
-  console.log('Installing dependencies...');
-  await run('npm', ['install'], { cwd: repoDir });
+    console.log('Installing dependencies...');
+    await run('npm', ['install'], { cwd: repoDir });
 
-  const targetArtifact = path.join(repoDir, 'src', 'artifacts', 'index.tsx');
-  await fs.promises.copyFile(absFile, targetArtifact);
-
-  console.log('Building artifact...');
-  await run('npx', ['vite', 'build'], { cwd: repoDir });
-
-  console.log('Starting preview server... (press Ctrl+C to stop)');
-  const preview = spawn('npx', ['vite', 'preview'], { cwd: repoDir, stdio: 'inherit' });
-  process.on('SIGINT', () => preview.kill('SIGINT'));
-
-  preview.on('exit', async () => {
-    if (keep) {
-      const dest = path.join(cwd, path.basename(fileArg, path.extname(fileArg)));
-      await fs.promises.rm(dest, { recursive: true, force: true });
-      await fs.promises.rename(repoDir, dest);
-      await fs.promises.rm(tmpBase, { recursive: true, force: true });
-      console.log(`Project kept at ${dest}`);
+    if (!useDefault && absFile) {
+      const targetArtifact = path.join(repoDir, 'src', 'artifacts', 'index.tsx');
+      console.log('Copying artifact file...');
+      await fs.promises.copyFile(absFile, targetArtifact);
     } else {
-      await fs.promises.rm(tmpBase, { recursive: true, force: true });
-      console.log('Temporary project removed');
+      console.log('Using default artifact content...');
     }
-  });
+
+    // Start vite
+    const preview = spawn('npx', ['vite', '--open'], { cwd: repoDir, stdio: 'inherit' });
+
+    process.on('SIGINT', () => {
+      console.error(`${os.EOL}🛑 Stopping development server...`);
+      preview.kill('SIGINT');
+    });
+
+    preview.on('exit', async () => {
+      await cleanup(tmpBase, keep, cwd, fileArg, repoDir);
+    });
+  } catch (err) {
+    console.error('Error:', err.message);
+    await cleanup(tmpBase, false, cwd, fileArg, repoDir);
+    process.exit(1);
+  }
 }
 
-main().catch(err => {
-  console.error(err.message);
-  process.exit(1);
-});
+main();


### PR DESCRIPTION
## Summary
- add `npx run-claude-artifact` CLI for running single Claude artifacts
- document using the CLI without cloning the repo
- include publish instructions for the new package

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `cd npx && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b97e305e2c832385a2c5897003c692